### PR TITLE
backend: add /version endpoint

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -1,0 +1,26 @@
+import express from "express";
+import fs from "fs";
+
+const app = express();
+const startedAt = Date.now();
+
+app.get("/health", (req, res) => {
+  const uptime = Math.floor((Date.now() - startedAt) / 1000);
+  res.status(200).json({ status: "ok", uptime });
+});
+
+app.get("/version", (_req, res) => {
+  try {
+    const pkg = JSON.parse(fs.readFileSync(new URL("./package.json", import.meta.url)));
+    res.json({ version: pkg.version || "0.0.0" });
+  } catch {
+    res.json({ version: "unknown" });
+  }
+});
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => {
+  console.log(`[backend] listening on http://localhost:${port}`);
+});
+
+


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduces a lightweight HTTP service with two public endpoints:
    * GET /health — returns JSON with service status and uptime.
    * GET /version — returns JSON with the running application version; falls back to “0.0.0” or “unknown” if unavailable.
  * Server runs on a configurable port via the PORT environment variable (defaults to 3000) and logs a startup message for visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->