### PR TITLE
backend: add /version endpoint

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -1,0 +1,26 @@
+import express from "express";
+import fs from "fs";
+
+const app = express();
+const startedAt = Date.now();
+
+app.get("/health", (req, res) => {
+  const uptime = Math.floor((Date.now() - startedAt) / 1000);
+  res.status(200).json({ status: "ok", uptime });
+});
+
+app.get("/version", (_req, res) => {
+  try {
+    const pkg = JSON.parse(fs.readFileSync(new URL("./package.json", import.meta.url)));
+    res.json({ version: pkg.version || "0.0.0" });
+  } catch {
+    res.json({ version: "unknown" });
+  }
+});
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => {
+  console.log(`[backend] listening on http://localhost:${port}`);
+});
+
+


### PR DESCRIPTION
### Summary
Added a new `/version` endpoint to the backend service.

### Details
- Implemented `/version` route in `index.js`
- Reads version from `package.json`
- Falls back to `"unknown"` if parsing fails
- Complements the existing `/health` endpoint

### How to Test
1. Start backend: `npm start`
2. Open browser or curl:
   - `http://localhost:3000/health` → should return `{ status: "ok", uptime: ... }`
   - `http://localhost:3000/version` → should return `{ version: "0.1.0" }`

### Notes
This will be part of the **First public release milestone**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Introduced a lightweight backend server exposing public HTTP endpoints:
    - GET /health: returns service status and uptime (seconds since startup).
    - GET /version: returns the application version with safe fallbacks when unavailable.
  * Server listens on the configured port (from environment) or defaults to 3000 and logs a startup message for visibility.
  * Adds robust handling for missing or unreadable version information to ensure consistent responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->