### PR TITLE
ci(status): add on-demand daily status message

### DIFF
--- a/.github/workflows/on-demand-status.yml
+++ b/.github/workflows/on-demand-status.yml
@@ -25,54 +25,31 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const who = core.getInput('who');
-            const scope = core.getInput('scope');
-            const sinceDays = parseInt(core.getInput('sinceDays'), 10);
-            const since = new Date(Date.now() - sinceDays*24*60*60*1000).toISOString();
+            // === SAFE UTC DATES (no locale parsing) ===
+            const HOURS = 24;
+            const now = new Date();
+            const sinceISO = new Date(now.getTime() - HOURS*60*60*1000).toISOString();
+            
             const { owner, repo } = context.repo;
-
-            const mapWho = {
-              bob:  'Bob-HickoryAI',
-              lara: 'Lara-HickoryAI',
-              suzy: 'Suzy-HickoryAI',
-              lucy: 'Lucy-HickoryAI'
-            };
-            const userFilter = (who === 'all') ? null : mapWho[who.toLowerCase()];
-            const labelMap = {
-              wallet: 'comp:wallet',
-              hicscan: 'comp:hicscan',
-              dex: 'comp:dex',
-              infra: 'comp:infra',
-              docs: 'comp:docs',
-              whitepaper: 'comp:whitepaper'
-            };
-            const labelFilter = (scope === 'all') ? null : labelMap[scope.toLowerCase()];
-
-            const prs = await github.paginate(github.rest.pulls.list, { owner, repo, state: 'all', per_page: 100 });
-            const issues = await github.paginate(github.rest.issues.listForRepo, { owner, repo, state: 'all', per_page: 100, since });
-
-            const matchUser = (login) => !userFilter || (login && login.toLowerCase() === userFilter.toLowerCase());
-            const matchLabel = (labels=[]) => !labelFilter || labels.some(l => l.name === labelFilter);
-
-            const prsRecent = prs.filter(p =>
-              new Date(p.updated_at) >= new Date(since) &&
-              matchUser(p.user?.login) &&
-              matchLabel(p.labels)
+            
+            // Issues updated in last 24h (exclude PRs)
+            const issuesAll = await github.paginate(
+              github.rest.issues.listForRepo, { owner, repo, state: 'all', per_page: 100, since: sinceISO }
             );
-
-            const issuesDaily = issues.filter(i =>
-              !i.pull_request &&
-              matchLabel(i.labels) &&
-              matchUser(i.assignee?.login || i.user?.login) &&
-              (i.labels || []).some(l => l.name === 'status:daily')
-            );
-
-            const prLine = p => `• PR #${p.number} ${p.title} — ${p.state.toUpperCase()} — by ${p.user.login}  ${p.html_url}`;
-            const isLine = i => `• ${i.title} — by ${i.user.login}  ${i.html_url}`;
-
-            const list = (arr, f, max=12) => arr.slice(0, max).map(f).join('\n') || '• none';
-
-            const header = `🧭 **On-Demand Status** | who: \`${who}\`, scope: \`${scope}\`, since: ${since.substring(0,10)}`;
+            const issuesDaily = issuesAll.filter(i => !i.pull_request);
+            
+            // PRs updated in last 24h
+            const prsRecent = (await github.paginate(
+              github.rest.pulls.list, { owner, repo, state: 'all', per_page: 100 }
+            )).filter(p => new Date(p.updated_at).toISOString() >= sinceISO);
+            
+            // Formatters
+            const link = (t,u) => `[${t}](${u})`;
+            const isLine = i => `• #${i.number} ${i.title} — by ${i.user.login}  ${link('Issue', i.html_url)}`;
+            const prLine = p => `• #${p.number} ${p.title} — by ${p.user.login}  ${link('PR', p.html_url)}`;
+            const list = (arr, map, max=12) => arr.slice(0, max).map(map).join('\n') || '• none';
+            
+            const header = `📅 **Hickory Daily Status**  _(since ${sinceISO.substring(0,10)} ${sinceISO.substring(11,16)} UTC)_`;
             const text = [
               header, '',
               `**Daily státusz issue-k** (${issuesDaily.length})`,
@@ -81,7 +58,7 @@ jobs:
               list(prsRecent, prLine), '',
               `Repo: \`${owner}/${repo}\``
             ].join('\n');
-
+            
             core.setOutput('msg', text);
 
       - name: Send to Discord

--- a/.github/workflows/on-demand-status.yml
+++ b/.github/workflows/on-demand-status.yml
@@ -1,69 +1,38 @@
 name: Hickory On-Demand Status
 
 on:
-  workflow_dispatch:
-    inputs:
-      who:
-        description: "Ki? (bob|lara|suzy|lucy|all)"
-        required: true
-        default: "all"
-      scope:
-        description: "Komponens (wallet|hicscan|dex|infra|docs|whitepaper|all)"
-        required: true
-        default: "all"
-      sinceDays:
-        description: "Hány napra vissza?"
-        required: true
-        default: "7"
+  workflow_dispatch: {}
 
 jobs:
   status:
     runs-on: ubuntu-latest
     steps:
-      - name: Build status text
-        id: build
-        uses: actions/github-script@v7
-        with:
-          script: |
-            // === SAFE UTC DATES (no locale parsing) ===
-            const HOURS = 24;
-            const now = new Date();
-            const sinceISO = new Date(now.getTime() - HOURS*60*60*1000).toISOString();
-            
-            const { owner, repo } = context.repo;
-            
-            // Issues updated in last 24h (exclude PRs)
-            const issuesAll = await github.paginate(
-              github.rest.issues.listForRepo, { owner, repo, state: 'all', per_page: 100, since: sinceISO }
-            );
-            const issuesDaily = issuesAll.filter(i => !i.pull_request);
-            
-            // PRs updated in last 24h
-            const prsRecent = (await github.paginate(
-              github.rest.pulls.list, { owner, repo, state: 'all', per_page: 100 }
-            )).filter(p => new Date(p.updated_at).toISOString() >= sinceISO);
-            
-            // Formatters
-            const link = (t,u) => `[${t}](${u})`;
-            const isLine = i => `• #${i.number} ${i.title} — by ${i.user.login}  ${link('Issue', i.html_url)}`;
-            const prLine = p => `• #${p.number} ${p.title} — by ${p.user.login}  ${link('PR', p.html_url)}`;
-            const list = (arr, map, max=12) => arr.slice(0, max).map(map).join('\n') || '• none';
-            
-            const header = `📅 **Hickory Daily Status**  _(since ${sinceISO.substring(0,10)} ${sinceISO.substring(11,16)} UTC)_`;
-            const text = [
-              header, '',
-              `**Daily státusz issue-k** (${issuesDaily.length})`,
-              list(issuesDaily, isLine), '',
-              `**PR-ek (recent)** (${prsRecent.length})`,
-              list(prsRecent, prLine), '',
-              `Repo: \`${owner}/${repo}\``
-            ].join('\n');
-            
-            core.setOutput('msg', text);
-
-      - name: Send to Discord
+      - name: Send Daily Status to Discord
         uses: Ilshidur/action-discord@master
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         with:
-          args: ${{ steps.build.outputs.msg }}
+          args: |
+            📣 **Hickory – napi státusz**
+
+            • Wallet: specifikáció/UX váz szükséges, API-szerződés előkészítése folyamatban. ⟨confirm⟩
+            • HICScan: indexer + sémák tervezése indul; első block/tx lekérdezések PoC. ⟨confirm⟩
+            • HickoryDex: MVP-scope (pool, swap, liquidity) definiálás előtt. ⟨confirm⟩
+            • Backend: /version + /health, OpenAPI stub, Dockerize → következő sprint fókusz.
+            • Infra: Discord értesítések (push/PR/merge), Weekly & On-demand report **aktív**; main védett (PR-kötelező); CODEOWNERS él.
+            • Whitepaper/Funding: outline + deck v1 hiányzik, data room előkészítendő. ⟨confirm⟩
+            • Docs: Docusaurus/MkDocs keret + ADR napló bevezetése.
+
+            👤 **Felelősök**
+            – Lara: Wallet UX/UI + kliens váz
+            – Bob: Backend/API + indexer PoC
+            – Lucy: HICScan explorer
+            – Suzy: Docs/QA + riportok
+            – Co-CEO: Funding/Partners
+
+            ⏭️ **Next 48h**
+            1) Repo baseline (docs, contributing, release tags)
+            2) Backend OpenAPI + Dockerfile
+            3) Wallet flow & szerződés
+            4) Explorer PoC első végpontok
+            5) Riport metrikák bővítése (issues/releases)

--- a/.github/workflows/weekly-report.yml
+++ b/.github/workflows/weekly-report.yml
@@ -2,7 +2,7 @@ name: Hickory Weekly Report
 
 on:
   schedule:
-    - cron: "0 9 * * MON"     # hétfő 09:00 UTC
+    - cron: "0 6 * * MON"     # hétfő 09:00 UTC
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/weekly-report.yml
+++ b/.github/workflows/weekly-report.yml
@@ -2,7 +2,7 @@ name: Hickory Weekly Report
 
 on:
   schedule:
-    - cron: "0 6 * * MON"   # 06:00 UTC ≈ 07:00 CET (tél) / 08:00 CEST (nyár)
+    - cron: "0 6 * * MON"   # 06:00 UTC = 07:00 CET (tél) / 08:00 CEST (nyár)
   workflow_dispatch:
 
 jobs:
@@ -26,54 +26,50 @@ jobs:
               .filter(p => new Date(p.updated_at).toISOString() >= since);
 
             // Issues (nyitott/zárt az elmúlt 7 napban)
-            const issuesAll = await github.paginate(github.rest.issues.listForRepo, { owner, repo, state: 'all', per_page: 100, since });
-            const openedIssues = issuesAll.filter(i => !i.pull_request && new Date(i.created_at).toISOString() >= since);
-            const closedIssues = issuesAll.filter(i => !i.pull_request && i.closed_at && i.closed_at >= since);
+            const issuesAll = await github.paginate(github.rest.issues.listForRepo, { owner, repo, state: 'all', per_page: 100 });
+            const openedIssues = issuesAll.filter(i => !i.pull_request && new Date(i.created_at) >= new Date(since));
+            const closedIssues = issuesAll.filter(i => !i.pull_request && i.closed_at && new Date(i.closed_at) >= new Date(since));
 
-            // Commitek az elmúlt 7 napban
-            const commits = (await github.rest.repos.listCommits({ owner, repo, since, per_page: 100 })).data;
+            // Commitok az elmúlt 7 napban
+            const commits = (await github.rest.repos.listCommits({ owner, repo, since, per_page: 50 })).data;
 
             // Releases (utolsó / utóbbi 7 napban)
-            const releases = await github.paginate(github.rest.repos.listReleases, { owner, repo, per_page: 20 });
-            const recentReleases = releases.filter(r => r.published_at && r.published_at >= since);
+            const releases = await github.paginate(github.rest.repos.listReleases, { owner, repo, per_page: 10 });
+            const recentReleases = releases.filter(r => r.published_at && new Date(r.published_at) >= new Date(since));
             const lastRelease = releases[0];
 
             const link = (text, url) => `[${text}](${url})`;
-            const prLine = p => `• #${p.number} ${p.title} — by ${p.user.login}  ${link('PR', p.html_url)}`;
-            const isLine = i => `• #${i.number} ${i.title} — by ${i.user.login}  ${link('Issue', i.html_url)}`;
-            const cLine  = c => `• ${c.sha.substring(0,7)} — ${c.commit.message.split('\\n')[0]}  ${link('Commit', c.html_url)}`;
+            const prLine = p => `• #${p.number} ${p.title} — by ${p.user.login} (${link('PR', p.html_url)})`;
+            const issueLine = i => `• #${i.number} ${i.title} — by ${i.user.login} (${link('Issue', i.html_url)})`;
+            const cLine  = c => `• ${c.sha.substring(0,7)} ${c.commit.message.split('\n')[0]} — by ${c.commit.author.name}`;
 
-            const list = (arr, map, max=10) => arr.slice(0, max).map(map).join('\n') || '• none';
-
-            const header = `📊 **Hickory Weekly Report**  _(since ${since.substring(0,10)})_`;
-            const mergedBlock = `✅ **Merged PRs (${mergedPRs.length})**\n${list(mergedPRs, prLine)}`;
-            const openBlock   = `🧩 **Open PRs updated (${openPRs.length})**\n${list(openPRs, prLine)}`;
-            const issuesBlock = `❗ **Issues — opened: ${openedIssues.length}, closed: ${closedIssues.length}**\n` +
-                                `Opened:\n${list(openedIssues, isLine)}\n\nClosed:\n${list(closedIssues, isLine)}`;
-            const commitsBlock= `📦 **Commits (${commits.length})**\n${list(commits, cLine, 15)}`;
-            const releasesBlock = lastRelease
-              ? `🏷️ **Last release:** ${lastRelease.tag_name} — ${new Date(lastRelease.published_at).toISOString().substring(0,10)}  ${link('Release', lastRelease.html_url)}\n` +
-                (recentReleases.length ? `Recent (7d): ${recentReleases.map(r => r.tag_name).join(', ')}` : 'Recent (7d): none')
-              : '🏷️ **Last release:** none';
-
-            const quickLinks =
-              `🔗 **Quick links**\n` +
-              `• ${link('PRs', \`https://github.com/\${owner}/\${repo}/pulls\`)}  ` +
-              `• ${link('Issues', \`https://github.com/\${owner}/\${repo}/issues\`)}  ` +
-              `• ${link('Commits', \`https://github.com/\${owner}/\${repo}/commits\`)}  ` +
-              `• ${link('Actions', \`https://github.com/\${owner}/\${repo}/actions\`)}  ` +
-              `• ${link('Releases', \`https://github.com/\${owner}/\${repo}/releases\`)}`;
+            const list = (arr, map, max=8) => arr.slice(0, max).map(map).join('\n') || '• none';
 
             const text = [
-              header, '',
-              mergedBlock, '',
-              openBlock, '',
-              issuesBlock, '',
-              commitsBlock, '',
-              releasesBlock, '',
-              quickLinks, '',
-              `Repo: \`${owner}/${repo}\``
-            ].join('\n');
+              `📊 **Hickory Weekly Report** (since ${since.substring(0,10)})`,
+              ``,
+              `✅ **Merged PRs (${mergedPRs.length})**`,
+              list(mergedPRs, prLine),
+              ``,
+              `📂 **Open PRs updated (${openPRs.length})**`,
+              list(openPRs, prLine),
+              ``,
+              `🐛 **New Issues (${openedIssues.length})**`,
+              list(openedIssues, issueLine),
+              ``,
+              `🔒 **Closed Issues (${closedIssues.length})**`,
+              list(closedIssues, issueLine),
+              ``,
+              `📦 **Commits (${commits.length})**`,
+              list(commits, cLine),
+              ``,
+              `🚀 **Releases (${recentReleases.length})**`,
+              list(recentReleases, r => `• ${r.name || r.tag_name} — ${r.html_url}`),
+              ``,
+              lastRelease ? `📌 **Latest Release:** ${lastRelease.name || lastRelease.tag_name} (${lastRelease.html_url})` : '',
+              ``,
+              `Repo: ${owner}/${repo}`
+            ].filter(Boolean).join('\n');
 
             core.setOutput('msg', text);
 
@@ -82,4 +78,7 @@ jobs:
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         with:
-          args: ${{ steps.build.outputs.msg }}
+          args: ${{ steps.build.outputs.msg }
+
+
+

--- a/.github/workflows/weekly-report.yml
+++ b/.github/workflows/weekly-report.yml
@@ -1,65 +1,57 @@
-name: Weekly Status to Discord
+name: Hickory Weekly Report
 
 on:
   schedule:
-    # Hétfő 07:00 UTC (hazai időben nyáron 09:00, télen 08:00). Átírható.
-    - cron: "0 7 * * MON"
+    - cron: "0 9 * * MON"     # hétfő 09:00 UTC
   workflow_dispatch:
 
 jobs:
-  weekly:
+  report:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: read
-      issues: read
-    env:
-      GH_TOKEN: ${{ github.token }}   # gh CLI-hez
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - name: Build weekly summary (last 7 days)
+        id: build
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const since = new Date(Date.now() - 7*24*60*60*1000).toISOString();
+            const { owner, repo } = context.repo;
 
-      - name: Build weekly summary
-        id: summary
-        run: |
-          set -euo pipefail
-          REPO="${{ github.repository }}"
-          DEFAULT_BRANCH="$(gh repo view "$REPO" --json defaultBranchRef --jq .defaultBranchRef.name)"
-          OPEN_ISSUES="$(gh issue list --state open --json number --jq 'length' || echo 0)"
-          OPEN_PRS="$(gh pr list --state open --json number --jq 'length' || echo 0)"
-          MERGED_PRS="$(gh pr list --state merged --json number --jq 'length' || echo 0)"
-          CLOSED_ISSUES="$(gh issue list --state closed --search 'closed:>=-7d' --json number --jq 'length' || echo 0)"
-          COMMITS="$(gh api repos/$REPO/commits --paginate -F sha="$DEFAULT_BRANCH" -f since="$(date -u -d '7 days ago' +%Y-%m-%dT%H:%M:%SZ)" --jq 'length' || echo 0)"
-          LAST_RELEASE="$(gh release list --limit 1 --json tagName,publishedAt --jq '.[0] // {}' || echo '{}')"
-          REL_TAG="$(echo "$LAST_RELEASE" | jq -r '.tagName // "—"')"
-          REL_DATE="$(echo "$LAST_RELEASE" | jq -r '.publishedAt // "—"')"
+            const mergedPRs = (await github.paginate(
+              github.rest.pulls.list, { owner, repo, state: 'closed', per_page: 100 }
+            )).filter(p => p.merged_at && p.merged_at >= since);
 
-          PRS_URL="https://github.com/$REPO/pulls"
-          ISSUES_URL="https://github.com/$REPO/issues"
-          ACTIONS_URL="https://github.com/$REPO/actions"
-          COMMITS_URL="https://github.com/$REPO/commits/$DEFAULT_BRANCH"
-          RELEASES_URL="https://github.com/$REPO/releases"
+            const openPRs = (await github.paginate(
+              github.rest.pulls.list, { owner, repo, state: 'open', per_page: 100 }
+            )).filter(p => new Date(p.updated_at).toISOString() >= since);
 
-          echo "text<<MSG" >> $GITHUB_OUTPUT
-          echo "📊 **Hickory – heti státusz**" >> $GITHUB_OUTPUT
-          echo "" >> $GITHUB_OUTPUT
-          echo "• Repo: **$REPO**  |  Branch: **$DEFAULT_BRANCH**" >> $GITHUB_OUTPUT
-          echo "• Nyitott PR-k: **$OPEN_PRS**  |  Nyitott issue-k: **$OPEN_ISSUES**" >> $GITHUB_OUTPUT
-          echo "• Múlt héten merge-ölt PR-k: **$MERGED_PRS**  |  Zárt issue-k (7d): **$CLOSED_ISSUES**" >> $GITHUB_OUTPUT
-          echo "• Commitok (7d): **$COMMITS**" >> $GITHUB_OUTPUT
-          echo "• Utolsó release: **$REL_TAG** (_$REL_DATE_)" >> $GITHUB_OUTPUT
-          echo "" >> $GITHUB_OUTPUT
-          echo "🔗 Hivatkozások:" >> $GITHUB_OUTPUT
-          echo "  • PR-k: $PRS_URL" >> $GITHUB_OUTPUT
-          echo "  • Issue-k: $ISSUES_URL" >> $GITHUB_OUTPUT
-          echo "  • Commitok: $COMMITS_URL" >> $GITHUB_OUTPUT
-          echo "  • Actions futások: $ACTIONS_URL" >> $GITHUB_OUTPUT
-          echo "  • Release-ek: $RELEASES_URL" >> $GITHUB_OUTPUT
- 
+            const commits = (await github.rest.repos.listCommits({
+              owner, repo, since, per_page: 50
+            })).data;
 
-      - name: Send to Discord
+            const prLine = p => `• #${p.number} ${p.title} — by ${p.user.login}`;
+            const cLine  = c => `• ${c.sha.substring(0,7)} ${c.commit.message.split('\n')[0]} — by ${c.commit.author.name}`;
+            const list   = (arr, map, max=8) => arr.slice(0, max).map(map).join('\n') || '• none';
+
+            const text = [
+              `📊 **Hickory Weekly Report** (since ${since.substring(0,10)})`,
+              ``,
+              `**Merged PRs (${mergedPRs.length})**`,
+              list(mergedPRs, prLine),
+              ``,
+              `**Open PRs updated (${openPRs.length})**`,
+              list(openPRs, prLine),
+              ``,
+              `**Commits (${commits.length})**`,
+              list(commits, cLine),
+              ``,
+              `Repo: ${owner}/${repo}`
+            ].join('\n');
+
+            core.setOutput('msg', text);
+      - name: Send Weekly Report to Discord
         uses: Ilshidur/action-discord@master
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         with:
-          args: ${{ steps.summary.outputs.text }}
+          args: ${{ steps.build.outputs.msg }}

--- a/.github/workflows/weekly-report.yml
+++ b/.github/workflows/weekly-report.yml
@@ -2,7 +2,7 @@ name: Hickory Weekly Report
 
 on:
   schedule:
-    - cron: "0 6 * * MON"     # hétfő 09:00 UTC
+    - cron: "0 6 * * MON"   # 06:00 UTC ≈ 07:00 CET (tél) / 08:00 CEST (nyár)
   workflow_dispatch:
 
 jobs:
@@ -17,38 +17,66 @@ jobs:
             const since = new Date(Date.now() - 7*24*60*60*1000).toISOString();
             const { owner, repo } = context.repo;
 
-            const mergedPRs = (await github.paginate(
-              github.rest.pulls.list, { owner, repo, state: 'closed', per_page: 100 }
-            )).filter(p => p.merged_at && p.merged_at >= since);
+            // PR-k (merged az elmúlt 7 napban)
+            const prsClosed = await github.paginate(github.rest.pulls.list, { owner, repo, state: 'closed', per_page: 100 });
+            const mergedPRs = prsClosed.filter(p => p.merged_at && p.merged_at >= since);
 
-            const openPRs = (await github.paginate(
-              github.rest.pulls.list, { owner, repo, state: 'open', per_page: 100 }
-            )).filter(p => new Date(p.updated_at).toISOString() >= since);
+            // Nyitott PR-k, amik frissültek az elmúlt 7 napban
+            const openPRs = (await github.paginate(github.rest.pulls.list, { owner, repo, state: 'open', per_page: 100 }))
+              .filter(p => new Date(p.updated_at).toISOString() >= since);
 
-            const commits = (await github.rest.repos.listCommits({
-              owner, repo, since, per_page: 50
-            })).data;
+            // Issues (nyitott/zárt az elmúlt 7 napban)
+            const issuesAll = await github.paginate(github.rest.issues.listForRepo, { owner, repo, state: 'all', per_page: 100, since });
+            const openedIssues = issuesAll.filter(i => !i.pull_request && new Date(i.created_at).toISOString() >= since);
+            const closedIssues = issuesAll.filter(i => !i.pull_request && i.closed_at && i.closed_at >= since);
 
-            const prLine = p => `• #${p.number} ${p.title} — by ${p.user.login}`;
-            const cLine  = c => `• ${c.sha.substring(0,7)} ${c.commit.message.split('\n')[0]} — by ${c.commit.author.name}`;
-            const list   = (arr, map, max=8) => arr.slice(0, max).map(map).join('\n') || '• none';
+            // Commitek az elmúlt 7 napban
+            const commits = (await github.rest.repos.listCommits({ owner, repo, since, per_page: 100 })).data;
+
+            // Releases (utolsó / utóbbi 7 napban)
+            const releases = await github.paginate(github.rest.repos.listReleases, { owner, repo, per_page: 20 });
+            const recentReleases = releases.filter(r => r.published_at && r.published_at >= since);
+            const lastRelease = releases[0];
+
+            const link = (text, url) => `[${text}](${url})`;
+            const prLine = p => `• #${p.number} ${p.title} — by ${p.user.login}  ${link('PR', p.html_url)}`;
+            const isLine = i => `• #${i.number} ${i.title} — by ${i.user.login}  ${link('Issue', i.html_url)}`;
+            const cLine  = c => `• ${c.sha.substring(0,7)} — ${c.commit.message.split('\\n')[0]}  ${link('Commit', c.html_url)}`;
+
+            const list = (arr, map, max=10) => arr.slice(0, max).map(map).join('\n') || '• none';
+
+            const header = `📊 **Hickory Weekly Report**  _(since ${since.substring(0,10)})_`;
+            const mergedBlock = `✅ **Merged PRs (${mergedPRs.length})**\n${list(mergedPRs, prLine)}`;
+            const openBlock   = `🧩 **Open PRs updated (${openPRs.length})**\n${list(openPRs, prLine)}`;
+            const issuesBlock = `❗ **Issues — opened: ${openedIssues.length}, closed: ${closedIssues.length}**\n` +
+                                `Opened:\n${list(openedIssues, isLine)}\n\nClosed:\n${list(closedIssues, isLine)}`;
+            const commitsBlock= `📦 **Commits (${commits.length})**\n${list(commits, cLine, 15)}`;
+            const releasesBlock = lastRelease
+              ? `🏷️ **Last release:** ${lastRelease.tag_name} — ${new Date(lastRelease.published_at).toISOString().substring(0,10)}  ${link('Release', lastRelease.html_url)}\n` +
+                (recentReleases.length ? `Recent (7d): ${recentReleases.map(r => r.tag_name).join(', ')}` : 'Recent (7d): none')
+              : '🏷️ **Last release:** none';
+
+            const quickLinks =
+              `🔗 **Quick links**\n` +
+              `• ${link('PRs', \`https://github.com/\${owner}/\${repo}/pulls\`)}  ` +
+              `• ${link('Issues', \`https://github.com/\${owner}/\${repo}/issues\`)}  ` +
+              `• ${link('Commits', \`https://github.com/\${owner}/\${repo}/commits\`)}  ` +
+              `• ${link('Actions', \`https://github.com/\${owner}/\${repo}/actions\`)}  ` +
+              `• ${link('Releases', \`https://github.com/\${owner}/\${repo}/releases\`)}`;
 
             const text = [
-              `📊 **Hickory Weekly Report** (since ${since.substring(0,10)})`,
-              ``,
-              `**Merged PRs (${mergedPRs.length})**`,
-              list(mergedPRs, prLine),
-              ``,
-              `**Open PRs updated (${openPRs.length})**`,
-              list(openPRs, prLine),
-              ``,
-              `**Commits (${commits.length})**`,
-              list(commits, cLine),
-              ``,
-              `Repo: ${owner}/${repo}`
+              header, '',
+              mergedBlock, '',
+              openBlock, '',
+              issuesBlock, '',
+              commitsBlock, '',
+              releasesBlock, '',
+              quickLinks, '',
+              `Repo: \`${owner}/${repo}\``
             ].join('\n');
 
             core.setOutput('msg', text);
+
       - name: Send Weekly Report to Discord
         uses: Ilshidur/action-discord@master
         env:

--- a/discord-graphic-test.txt
+++ b/discord-graphic-test.txt
@@ -1,0 +1,1 @@
+Discord graphic test Thu Aug 21 22:25:20 CEST 2025


### PR DESCRIPTION
Fix, strukturált napi státusz Discordra (workflow_dispatch).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Weekly Discord report now includes merged/open PRs, new/closed issues (last 7 days), commits, releases, and latest release, with emoji headers, clickable links, and auto-hiding empty sections.
  - Daily status message simplified to a standardized template.

- Chores
  - Weekly report schedule adjusted to Mondays at 06:00 (CET/CEST).
  - Removed manual inputs from the on-demand status trigger.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->